### PR TITLE
Fix Cloudflare bypass with complete browser headers

### DIFF
--- a/ygghybrid.yml
+++ b/ygghybrid.yml
@@ -64,12 +64,9 @@ caps:
   allowrawsearch: true
 
 settings:
-  - name: ygg_cookie
+  - name: cookie
     type: text
-    label: Cookie ygg_
-  - name: cf_clearance
-    type: text
-    label: Cookie cf_clearance
+    label: Full Cookie String (from browser)
   - name: useragent
     type: text
     label: User-Agent
@@ -180,5 +177,18 @@ search:
 
 download:
   headers:
+    Accept: ["text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"]
+    Accept-Language: ["fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7"]
+    Cache-Control: ["no-cache"]
+    Pragma: ["no-cache"]
+    Referer: ["https://www.yggtorrent.org/"]
+    Sec-Ch-Ua: ["\"Chromium\";v=\"143\", \"Not.A/Brand\";v=\"24\", \"Microsoft Edge\";v=\"143\""]
+    Sec-Ch-Ua-Mobile: ["?0"]
+    Sec-Ch-Ua-Platform: ["\"Windows\""]
+    Sec-Fetch-Dest: ["document"]
+    Sec-Fetch-Mode: ["navigate"]
+    Sec-Fetch-Site: ["same-origin"]
+    Sec-Fetch-User: ["?1"]
+    Upgrade-Insecure-Requests: ["1"]
     User-Agent: ["{{ .Config.useragent }}"]
-    Cookie: ["ygg_={{ .Config.ygg_cookie }}; cf_clearance={{ .Config.cf_clearance }}"]
+    Cookie: ["{{ .Config.cookie }}"]


### PR DESCRIPTION
## Résumé
Cette PR améliore le contournement de la protection Cloudflare en ajoutant des en-têtes de navigateur complets aux requêtes de téléchargement, résolvant les erreurs 403 Forbidden que les utilisateurs rencontrent lors du téléchargement de torrents.

## Problème
Les utilisateurs rencontraient des erreurs 403 Forbidden de Cloudflare lors de la tentative de téléchargement de torrents, même avec des cookies valides. L'implémentation précédente n'envoyait que les en-têtes User-Agent et Cookie, ce qui était insuffisant pour les règles de protection Cloudflare plus strictes.

## Modifications

### 1. Configuration des Cookies Simplifiée
- **Avant** : Champs séparés pour `ygg_cookie` et `cf_clearance`
- **Après** : Un seul champ `cookie` pour la chaîne de cookies complète du navigateur
- **Avantages** :
  - Configuration plus facile (coller la chaîne de cookies complète depuis DevTools)
  - Garantit que tous les cookies nécessaires sont inclus (account_created, account_authority, yggxf_user, etc.)

### 2. Ajout d'En-têtes de Navigateur Complets
Ajout d'en-têtes complets pour imiter les requêtes d'un vrai navigateur :
- `Accept` : Négociation appropriée du type de contenu
- `Accept-Language` : Préférences de langue
- `Cache-Control` & `Pragma` : Directives de cache
- `Referer` : Référence au domaine YGG
- `Sec-Ch-Ua` : Identification du navigateur
- `Sec-Ch-Ua-Mobile` & `Sec-Ch-Ua-Platform` : Informations sur l'appareil
- `Sec-Fetch-Dest`, `Sec-Fetch-Mode`, `Sec-Fetch-Site`, `Sec-Fetch-User` : Contexte de la requête
- `Upgrade-Insecure-Requests` : Préférence de mise à niveau HTTPS

## Pourquoi Ça Fonctionne
La protection Cloudflare ne valide pas seulement les cookies - elle analyse l'empreinte complète de la requête. En incluant tous les en-têtes standard du navigateur, les requêtes deviennent indiscernables du trafic légitime d'un navigateur, contournant avec succès les défis Cloudflare.

## Tests
- ✅ Testé avec des cookies frais (cf_clearance expire ~30 jours)
- ✅ Les téléchargements contournent avec succès les erreurs 403 Forbidden de Cloudflare
- ✅ Maintient la compatibilité avec l'architecture YGG Hybrid (recherche via YggAPI, téléchargement via YGG direct)
- ✅ Les torrents arrivent correctement dans qBittorrent

## Guide de Migration
Les utilisateurs devront :
1. Supprimer l'indexeur YGG Hybrid existant dans Prowlarr
2. Le rajouter avec la configuration mise à jour :
   - **Chaîne de Cookies Complète** : Chaîne de cookies complète depuis DevTools du navigateur (F12 → Application → Cookies)
   - **User-Agent** : Chaîne user-agent du navigateur

## Notes
- L'expiration des cookies reste ~30 jours (cookie cf_clearance)
- Les utilisateurs devront rafraîchir les cookies mensuellement lorsque les téléchargements commenceront à échouer
- Envisager de documenter le processus d'extraction des cookies dans le README